### PR TITLE
Made the template ID of local data folders to be configurable.

### DIFF
--- a/source/App_Config/Include/zLocalDatasources/LocalDatasources.config
+++ b/source/App_Config/Include/zLocalDatasources/LocalDatasources.config
@@ -1,13 +1,16 @@
 ﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
   <sitecore>
+    <settings>
+      <setting name="LocalDatasources.DataFolderTemplateId" value="{A37C4ADC-A626-4807-ACDD-748AD26C4144}" />
+    </settings>
     <pipelines>
       <getRenderingDatasource>
         <processor patch:before="*[@type='Sitecore.Pipelines.GetRenderingDatasource.CheckDialogState, Sitecore.Kernel']" type="TheReference.DotNet.Sitecore.LocalDatasources.Infrastructure.Pipelines.AddLocalDatasource, TheReference.DotNet.Sitecore.LocalDatasources" />
       </getRenderingDatasource>
     </pipelines>
-	  <commands>
-		  <command name="webedit:addrendering" type="TheReference.DotNet.Sitecore.LocalDatasources.Infrastructure.Commands.AddRendering, TheReference.DotNet.Sitecore.LocalDatasources" patch:instead="*[@name='webedit:addrendering']" />
-	  </commands>
+      <commands>
+        <command name="webedit:addrendering" type="TheReference.DotNet.Sitecore.LocalDatasources.Infrastructure.Commands.AddRendering, TheReference.DotNet.Sitecore.LocalDatasources" patch:instead="*[@name='webedit:addrendering']" />
+      </commands>
     <events>
       <event name="item:added">
         <handler patch:before="*[1]" type="TheReference.DotNet.Sitecore.LocalDatasources.Infrastructure.Events.ItemLocalDatasourcesHandler, TheReference.DotNet.Sitecore.LocalDatasources" method="OnItemAdded" />

--- a/source/Infrastructure/Pipelines/AddLocalDatasource.cs
+++ b/source/Infrastructure/Pipelines/AddLocalDatasource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Sitecore.Configuration;
 using Sitecore.Data;
 using Sitecore.Data.Items;
 using Sitecore.Globalization;
@@ -14,7 +15,13 @@ namespace TheReference.DotNet.Sitecore.LocalDatasources.Infrastructure.Pipelines
     {
         private const string RelativePath = "./";
 
-        internal static readonly Guid LocalDataFolderTemplateId = new Guid("{A37C4ADC-A626-4807-ACDD-748AD26C4144}");
+        internal static readonly Guid LocalDataFolderTemplateId;
+
+        static AddLocalDatasource()
+        {
+            string templateIdString = Settings.GetSetting("LocalDatasources.DataFolderTemplateId", "{A37C4ADC-A626-4807-ACDD-748AD26C4144}");
+            LocalDataFolderTemplateId = new Guid(templateIdString);
+        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "This is part of a sitecore pipeline and should not be static")]
         public void Process(GetRenderingDatasourceArgs args)


### PR DESCRIPTION
This change adds a new configuration setting to the LocalDatasources.config:

```
LocalDatasources.DataFolderTemplateId
```

This is for the solutions that already have their own template and only want to use the pipelines/events of this module.